### PR TITLE
商品情報編集機能

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require_relative "config/application"
+require_relative 'config/application'
 
 Rails.application.load_tasks

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,6 @@ class ApplicationController < ActionController::Base
   before_action :basic_auth
   before_action :configure_permitted_parameters, if: :devise_controller?
 
-
   private
 
   def basic_auth
@@ -12,6 +11,7 @@ class ApplicationController < ActionController::Base
   end
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :last_name, :first_name, :last_name_kana, :first_name_kana, :birthday])
+    devise_parameter_sanitizer.permit(:sign_up,
+                                      keys: [:nickname, :last_name, :first_name, :last_name_kana, :first_name_kana, :birthday])
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -22,6 +22,10 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def edit
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit]
-  before_action :move_to_index, only: :edit
   before_action :set_item, only: [:edit, :show, :update]
+  before_action :move_to_index, only: :edit
 
   def index
     @items = Item.all.order('created_at DESC')

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit]
   before_action :move_to_index, only: :edit
+  before_action :set_item, only: [:edit, :show, :update]
 
   def index
     @items = Item.all.order('created_at DESC')
@@ -20,15 +21,12 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def edit
-    @item = Item.find(params[:id])
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to item_path(@item)
     else
@@ -50,5 +48,9 @@ class ItemsController < ApplicationController
     return if user_signed_in? && current_user.id == user_id
 
     redirect_to action: :index
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,7 @@ class ItemsController < ApplicationController
   before_action :move_to_index, only: :edit
 
   def index
-    @items = Item.all.order("created_at DESC")
+    @items = Item.all.order('created_at DESC')
   end
 
   def new
@@ -13,7 +13,7 @@ class ItemsController < ApplicationController
   def create
     @item = Item.new(item_params)
     if @item.save
-      redirect_to "/"
+      redirect_to '/'
     else
       render :new, status: :unprocessable_entity
     end
@@ -39,16 +39,16 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:item_name, :description, :price, :category_id, :condition_id, :postage_id, :region_id, :shipping_data_id, :image).merge(user_id: current_user.id)
+    params.require(:item).permit(:item_name, :description, :price, :category_id, :condition_id, :postage_id, :region_id,
+                                 :shipping_data_id, :image).merge(user_id: current_user.id)
   end
 
   def move_to_index
     item = Item.find(params[:id])
     user_id = item.user_id
 
-    unless user_signed_in? && current_user.id == user_id
-      redirect_to action: :index
-    end
-  end
+    return if user_signed_in? && current_user.id == user_id
 
+    redirect_to action: :index
+  end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
+  before_action :authenticate_user!, only: [:new, :create, :edit]
+  before_action :move_to_index, only: :edit
 
   def index
     @items = Item.all.order("created_at DESC")
@@ -26,10 +27,28 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to item_path(@item)
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def item_params
     params.require(:item).permit(:item_name, :description, :price, :category_id, :condition_id, :postage_id, :region_id, :shipping_data_id, :image).merge(user_id: current_user.id)
+  end
+
+  def move_to_index
+    item = Item.find(params[:id])
+    user_id = item.user_id
+
+    unless user_signed_in? && current_user.id == user_id
+      redirect_to action: :index
+    end
   end
 
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
-  layout "mailer"
+  default from: 'from@example.com'
+  layout 'mailer'
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -15,5 +15,4 @@ class Category < ActiveHash::Base
 
   include ActiveHash::Associations
   has_many :items
-
-  end
+end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -6,10 +6,9 @@ class Condition < ActiveHash::Base
     { id: 4, name: '目立った傷や汚れなし' },
     { id: 5, name: 'やや傷や汚れあり' },
     { id: 6, name: '傷や汚れあり' },
-    { id: 7, name: '全体的に状態が悪い' },
+    { id: 7, name: '全体的に状態が悪い' }
   ]
 
   include ActiveHash::Associations
   has_many :items
-
-  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,13 +6,13 @@ class Item < ApplicationRecord
   belongs_to :region
   belongs_to :shipping_data
   belongs_to :user
-  #has_one_attached :order
+  # has_one_attached :order
   has_one_attached :image
 
   validates :image, presence: true
   validates :item_name, presence: true, length: { maximum: 40 }
   validates :description, presence: true, length: { maximum: 1000 }
-  validates :category_id, :condition_id, :postage_id, :region_id, :shipping_data_id, numericality: { other_than: 1 } 
+  validates :category_id, :condition_id, :postage_id, :region_id, :shipping_data_id, numericality: { other_than: 1 }
   validates :price, presence: true, numericality: {
     only_integer: true,
     greater_than_or_equal_to: 300,

--- a/app/models/postage.rb
+++ b/app/models/postage.rb
@@ -2,10 +2,9 @@ class Postage < ActiveHash::Base
   self.data = [
     { id: 1, name: '---' },
     { id: 2, name: '着払い(購入者負担)' },
-    { id: 3, name: '送料込み(出品者負担)' },
+    { id: 3, name: '送料込み(出品者負担)' }
   ]
 
   include ActiveHash::Associations
   has_many :items
-
-  end
+end

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -1,32 +1,31 @@
 class Region < ActiveHash::Base
   self.data = [
-      { id: 1, name: '---' },     { id: 2, name: '北海道'}, 
-      { id: 3, name: '青森県'},    { id: 4, name: '岩手県'},
-      { id: 5, name: '宮城県'},    { id: 6, name: '秋田県'}, 
-      { id: 7, name: '山形県'},    { id: 8, name: '福島県'}, 
-      { id: 9, name: '茨城県'},    { id: 10, name: '栃木県'},
-      { id: 11, name: '群馬県'},   { id: 12, name: '埼玉県'}, 
-      { id: 13, name: '千葉県'},   { id: 14, name: '東京都'}, 
-      { id: 15, name: '神奈川県'}, { id: 16, name: '新潟県'},
-      { id: 17, name: '富山県'},   { id: 18, name: '石川県'}, 
-      { id: 19, name: '福井県'},   { id: 20, name: '山梨県'}, 
-      { id: 21, name: '長野県'},   { id: 22, name: '岐阜県'},
-      { id: 23, name: '静岡県'},   { id: 24, name: '愛知県'}, 
-      { id: 25, name: '三重県'},   { id: 26, name: '滋賀県'}, 
-      { id: 27, name: '京都府'},   { id: 28, name: '大阪府'},
-      { id: 29, name: '兵庫県'},   { id: 30, name: '奈良県'}, 
-      { id: 31, name: '和歌山県'}, { id: 32, name: '鳥取県'}, 
-      { id: 33, name: '島根県'},   { id: 34, name: '岡山県'},
-      { id: 35, name: '広島県'},   { id: 36, name: '山口県'}, 
-      { id: 37, name: '徳島県'},   { id: 38, name: '香川県'}, 
-      { id: 39, name: '愛媛県'},   { id: 40, name: '高知県'},
-      { id: 41, name: '福岡県'},   { id: 42, name: '佐賀県'}, 
-      { id: 43, name: '長崎県'},   { id: 44, name: '熊本県'}, 
-      { id: 45, name: '大分県'},   { id: 46, name: '宮崎県'},
-      { id: 47, name: '鹿児島県'}, { id: 48, name: '沖縄県'}
+    { id: 1, name: '---' }, { id: 2, name: '北海道' },
+    { id: 3, name: '青森県' },    { id: 4, name: '岩手県' },
+    { id: 5, name: '宮城県' },    { id: 6, name: '秋田県' },
+    { id: 7, name: '山形県' },    { id: 8, name: '福島県' },
+    { id: 9, name: '茨城県' },    { id: 10, name: '栃木県' },
+    { id: 11, name: '群馬県' },   { id: 12, name: '埼玉県' },
+    { id: 13, name: '千葉県' },   { id: 14, name: '東京都' },
+    { id: 15, name: '神奈川県' }, { id: 16, name: '新潟県' },
+    { id: 17, name: '富山県' },   { id: 18, name: '石川県' },
+    { id: 19, name: '福井県' },   { id: 20, name: '山梨県' },
+    { id: 21, name: '長野県' },   { id: 22, name: '岐阜県' },
+    { id: 23, name: '静岡県' },   { id: 24, name: '愛知県' },
+    { id: 25, name: '三重県' },   { id: 26, name: '滋賀県' },
+    { id: 27, name: '京都府' },   { id: 28, name: '大阪府' },
+    { id: 29, name: '兵庫県' },   { id: 30, name: '奈良県' },
+    { id: 31, name: '和歌山県' }, { id: 32, name: '鳥取県' },
+    { id: 33, name: '島根県' },   { id: 34, name: '岡山県' },
+    { id: 35, name: '広島県' },   { id: 36, name: '山口県' },
+    { id: 37, name: '徳島県' },   { id: 38, name: '香川県' },
+    { id: 39, name: '愛媛県' },   { id: 40, name: '高知県' },
+    { id: 41, name: '福岡県' },   { id: 42, name: '佐賀県' },
+    { id: 43, name: '長崎県' },   { id: 44, name: '熊本県' },
+    { id: 45, name: '大分県' },   { id: 46, name: '宮崎県' },
+    { id: 47, name: '鹿児島県' }, { id: 48, name: '沖縄県' }
   ]
 
   include ActiveHash::Associations
   has_many :items
-
 end

--- a/app/models/shipping_data.rb
+++ b/app/models/shipping_data.rb
@@ -3,10 +3,9 @@ class ShippingData < ActiveHash::Base
     { id: 1, name: '---' },
     { id: 2, name: '1~2日で発送' },
     { id: 3, name: '2~3日で発送' },
-    { id: 4, name: '4~7日で発送' },
+    { id: 4, name: '4~7日で発送' }
   ]
 
   include ActiveHash::Associations
   has_many :items
-
-  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :items
-  #has_many :orders
+  # has_many :orders
 
   validates :nickname, presence: true
   validates :birthday, presence: true
@@ -20,7 +20,6 @@ class User < ApplicationRecord
     validates :last_name_kana
   end
 
-  PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?[\d])[a-z\d]+\z/i.freeze
-  validates_format_of :password, with: PASSWORD_REGEX, message: 'には英字と数字の両方を含めて設定してください' 
-
+  PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i
+  validates_format_of :password, with: PASSWORD_REGEX, message: 'には英字と数字の両方を含めて設定してください'
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -9,9 +9,7 @@ app/assets/stylesheets/items/new.css %>
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @item, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%= render 'shared/error_messages', model: f.object %>
 
     <%# 商品画像 %>
     <div class="img-upload">
@@ -141,7 +139,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', item_path(@item.id), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,7 +7,7 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%# render 'shared/error_messages', model: f.object %>
@@ -23,7 +23,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -33,13 +33,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :item_name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +52,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +73,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:postage_id, Postage.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:region_id, Region.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_data_id, ShippingData.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +101,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,7 +25,7 @@
 
     <% if user_signed_in? && current_user.id == @item.user_id %>
 
-      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
       <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
       <% elsif user_signed_in?%>

--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,6 @@
 # This file is used by Rack-based servers to start the application.
 
-require_relative "config/environment"
+require_relative 'config/environment'
 
 run Rails.application
 Rails.application.load_server

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,15 +1,15 @@
 FactoryBot.define do
   factory :item do
-    item_name        {Faker::Commerce.product_name}
-    description      {Faker::Lorem.sentence}
-    price            {Faker::Number.between(from: 300, to: 9999999)}
-    category_id      {Faker::Number.between(from: 2, to: 11)}
-    condition_id     {Faker::Number.between(from: 2, to: 7)}
-    postage_id       {Faker::Number.between(from: 2, to: 3)}
-    region_id        {Faker::Number.between(from: 2, to: 48)}
-    shipping_data_id {Faker::Number.between(from: 2, to: 4)}
+    item_name        { Faker::Commerce.product_name }
+    description      { Faker::Lorem.sentence }
+    price            { Faker::Number.between(from: 300, to: 9_999_999) }
+    category_id      { Faker::Number.between(from: 2, to: 11) }
+    condition_id     { Faker::Number.between(from: 2, to: 7) }
+    postage_id       { Faker::Number.between(from: 2, to: 3) }
+    region_id        { Faker::Number.between(from: 2, to: 48) }
+    shipping_data_id { Faker::Number.between(from: 2, to: 4) }
 
-    association :user 
+    association :user
 
     after(:build) do |item|
       item.image.attach(io: File.open('public/images/test_image.png'), filename: 'test_image.png')

--- a/spec/factories/oders.rb
+++ b/spec/factories/oders.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :oder do
-    
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,14 +1,13 @@
 FactoryBot.define do
   factory :user do
-    nickname              {Faker::Name.initials}
-    email                 {Faker::Internet.email}
-    password              {"1a" + Faker::Internet.password(min_length: 6)}
-    password_confirmation {password}
-    last_name              {'田中'}
-    first_name            {'太郎'}
-    last_name_kana        {'タナカ'}
-    first_name_kana       {'タロウ'}
-    birthday              {Faker::Date.birthday}
+    nickname              { Faker::Name.initials }
+    email                 { Faker::Internet.email }
+    password              { '1a' + Faker::Internet.password(min_length: 6) }
+    password_confirmation { password }
+    last_name { '田中' }
+    first_name            { '太郎' }
+    last_name_kana        { 'タナカ' }
+    first_name_kana       { 'タロウ' }
+    birthday              { Faker::Date.birthday }
   end
 end
-

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -5,31 +5,31 @@ RSpec.describe Item, type: :model do
     @item = FactoryBot.build(:item)
   end
 
-  describe "商品出品" do
-    context "商品出品できる場合" do
+  describe '商品出品' do
+    context '商品出品できる場合' do
       it '商品画像、商品名、商品の説明、値段、カテゴリー、商品状態、配送料、発送元地域、発送までの日数、価格が存在すれば登録できる' do
         expect(@item).to be_valid
       end
     end
 
-    context "商品出品できない場合" do
+    context '商品出品できない場合' do
       it '商品画像が空では出品できない' do
         @item.image = nil
         @item.valid?
         expect(@item.errors.full_messages).to include("Image can't be blank")
       end
       it '商品名が空では出品できない' do
-        @item.item_name = ""
+        @item.item_name = ''
         @item.valid?
         expect(@item.errors.full_messages).to include("Item name can't be blank")
       end
       it '商品名が41文字以上では出品できない' do
         @item.item_name = Faker::Commerce.product_name + Faker::Lorem.characters(number: 40)
         @item.valid?
-        expect(@item.errors.full_messages).to include("Item name is too long (maximum is 40 characters)")
+        expect(@item.errors.full_messages).to include('Item name is too long (maximum is 40 characters)')
       end
       it '商品の説明が空では出品できない' do
-        @item.description = ""
+        @item.description = ''
         @item.valid?
         expect(@item.errors.full_messages).to include("Description can't be blank")
       end
@@ -37,57 +37,57 @@ RSpec.describe Item, type: :model do
       it '商品の説明が1001文字以上では出品できない' do
         @item.description = Faker::Lorem.characters(number: 1001)
         @item.valid?
-        expect(@item.errors.full_messages).to include("Description is too long (maximum is 1000 characters)")
+        expect(@item.errors.full_messages).to include('Description is too long (maximum is 1000 characters)')
       end
       it 'カテゴリーが未選択では出品できない' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category must be other than 1")
+        expect(@item.errors.full_messages).to include('Category must be other than 1')
       end
       it '商品状態が未選択では出品できない' do
         @item.condition_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Condition must be other than 1")
+        expect(@item.errors.full_messages).to include('Condition must be other than 1')
       end
       it '配送料の負担が未選択では出品できない' do
         @item.postage_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Postage must be other than 1")
+        expect(@item.errors.full_messages).to include('Postage must be other than 1')
       end
       it '発送元の地域が未選択では出品できない' do
         @item.region_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Region must be other than 1")
+        expect(@item.errors.full_messages).to include('Region must be other than 1')
       end
       it '発送までの日数が未選択では出品できない' do
         @item.shipping_data_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping data must be other than 1")
+        expect(@item.errors.full_messages).to include('Shipping data must be other than 1')
       end
       it '価格が空では出品できない' do
-        @item.price = ""
+        @item.price = ''
         @item.valid?
         expect(@item.errors.full_messages).to include("Price can't be blank")
       end
       it '価格が300円より低いと出品できない' do
         @item.price = Faker::Number.between(from: 1, to: 299)
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be greater than or equal to 300")
+        expect(@item.errors.full_messages).to include('Price must be greater than or equal to 300')
       end
       it '価格が9,999,999円より高いと出品できない' do
-        @item.price = Faker::Number.between(from: 10000000, to: 20000000)
+        @item.price = Faker::Number.between(from: 10_000_000, to: 20_000_000)
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be less than or equal to 9999999")
+        expect(@item.errors.full_messages).to include('Price must be less than or equal to 9999999')
       end
       it '価格に半角数字以外が含まれている場合は出品できない' do
-        @item.price = "aあアｱ"
+        @item.price = 'aあアｱ'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
       it 'userが紐付いていないと保存できない' do
         @item.user = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("User must exist")
+        expect(@item.errors.full_messages).to include('User must exist')
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe User, type: :model do
     @user = FactoryBot.build(:user)
   end
 
-  describe "ユーザー新規登録" do
-    context "新規登録できる場合" do
+  describe 'ユーザー新規登録' do
+    context '新規登録できる場合' do
       it 'nicknameとemail、passwordとpassword_confirmation、名前、誕生日が存在すれば登録できる' do
         expect(@user).to be_valid
       end
     end
 
-    context "新規登録できない場合" do
+    context '新規登録できない場合' do
       it 'nicknameが空では登録できない' do
         @user.nickname = ''
         @user.valid?
@@ -33,7 +33,7 @@ RSpec.describe User, type: :model do
       it 'emailは@を含まないと登録できない' do
         @user.email = '111111'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Email is invalid")
+        expect(@user.errors.full_messages).to include('Email is invalid')
       end
       it 'passwordが空では登録できない' do
         @user.password = ''
@@ -49,17 +49,20 @@ RSpec.describe User, type: :model do
       it '英字のみのパスワードでは登録できない' do
         @user.password = 'aaaaaa'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password", "Password には英字と数字の両方を含めて設定してください")
+        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password",
+                                                      'Password には英字と数字の両方を含めて設定してください')
       end
       it '数字のみのパスワードでは登録できない' do
         @user.password = '111111'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password", "Password には英字と数字の両方を含めて設定してください")
+        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password",
+                                                      'Password には英字と数字の両方を含めて設定してください')
       end
       it '全角文字を含むパスワードでは登録できない' do
         @user.password = '1aaaaaa１'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password", "Password には英字と数字の両方を含めて設定してください")
+        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password",
+                                                      'Password には英字と数字の両方を含めて設定してください')
       end
       it 'passwordとpassword_confirmationが不一致では登録できない' do
         @user.password_confirmation = 'asdfgh1'
@@ -70,7 +73,7 @@ RSpec.describe User, type: :model do
         @user.password = Faker::Internet.password(min_length: 129, max_length: 150)
         @user.password_confirmation = @user.password
         @user.valid?
-      expect(@user.errors.full_messages).to include("Password is too long (maximum is 128 characters)")
+        expect(@user.errors.full_messages).to include('Password is too long (maximum is 128 characters)')
       end
       it '姓（全角）が空だと登録できない' do
         @user.last_name = ''
@@ -80,7 +83,7 @@ RSpec.describe User, type: :model do
       it '姓（全角）に半角文字が含まれていると登録できない' do
         @user.last_name = 'a田中'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name 全角文字を使用してください")
+        expect(@user.errors.full_messages).to include('Last name 全角文字を使用してください')
       end
       it '名（全角）が空だと登録できない' do
         @user.first_name = ''
@@ -90,7 +93,7 @@ RSpec.describe User, type: :model do
       it '名（全角）が空だと登録できない' do
         @user.first_name = 'a太郎'
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name 全角文字を使用してください")
+        expect(@user.errors.full_messages).to include('First name 全角文字を使用してください')
       end
       it '姓（カナ）が空だと登録できない' do
         @user.last_name_kana = ''
@@ -98,9 +101,9 @@ RSpec.describe User, type: :model do
         expect(@user.errors.full_messages).to include("Last name kana can't be blank")
       end
       it '姓（カナ）にカタカナ以外の文字（平仮名・漢字・英数字・記号）が含まれていると登録できない' do
-        @user.last_name_kana = "あ多4a#"
+        @user.last_name_kana = 'あ多4a#'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name kana 全角文字を使用してください")
+        expect(@user.errors.full_messages).to include('Last name kana 全角文字を使用してください')
       end
       it '名（カナ）が空だと登録できない' do
         @user.first_name_kana = ''
@@ -108,16 +111,15 @@ RSpec.describe User, type: :model do
         expect(@user.errors.full_messages).to include("First name kana can't be blank")
       end
       it '名（カナ）にカタカナ以外の文字（平仮名・漢字・英数字・記号）が含まれていると登録できない' do
-        @user.first_name_kana = "あ多4a#"
+        @user.first_name_kana = 'あ多4a#'
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name kana 全角文字を使用してください")
+        expect(@user.errors.full_messages).to include('First name kana 全角文字を使用してください')
       end
       it 'birthdayが空では登録できない' do
         @user.birthday = ''
         @user.valid?
         expect(@user.errors.full_messages).to include("Birthday can't be blank")
       end
-
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,51 +44,49 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  # https://rspec.info/features/3-12/rspec-core/configuration/zero-monkey-patching-mode/
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   # https://rspec.info/features/3-12/rspec-core/configuration/zero-monkey-patching-mode/
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :chrome, screen_size: [1400, 1400]

--- a/test/channels/application_cable/connection_test.rb
+++ b/test/channels/application_cable/connection_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class ApplicationCable::ConnectionTest < ActionCable::Connection::TestCase
   # test "connects with cookies" do

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class ItemsControllerTest < ActionDispatch::IntegrationTest
   # test "the truth" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
   # test "the truth" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,6 @@
-ENV["RAILS_ENV"] ||= "test"
-require_relative "../config/environment"
-require "rails/test_help"
+ENV['RAILS_ENV'] ||= 'test'
+require_relative '../config/environment'
+require 'rails/test_help'
 
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers


### PR DESCRIPTION
# What
商品情報編集機能の実装
《以下、プルリクエストへ記載するgyazo》
 ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/a10b3ac65414b25337f7035699e0ef31
 必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://gyazo.com/7974743f89be53ae4b0d66cbf62368a1
 入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://gyazo.com/f06d4544c909aa94d6f1a16dd7be83bb
 何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://gyazo.com/a04837d9ab298a5920065e06cbce9b42
 ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/c03bb9e53003ced670b57957809b8688
  ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/cd70e4cd92e8f9944d1eaa4d98a406e0
 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
https://gyazo.com/ae8d54bc6c296d27f7471fa57d413085
# Why
アップした商品情報を更新できるようにするため。